### PR TITLE
Fix metadata missing name

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name "le_chef"
 maintainer "Caroline Fenlon"
 maintainer_email "carfenlon@gmail.com"
 license "Apache 2.0"


### PR DESCRIPTION
Missing name attribute cause the issue below.

ridley-4.0.0/lib/ridley/chef/cookbook.rb:44:in `from_path': The metadata at '/var/folders/fg/74jslryj43qc2mzyg4ykw80h0000gn/T/d20140626-61753-1qnhnv6' does not contain a 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry. (Ridley::Errors::MissingNameAttribute)
