### PR TITLE
Improve GPG key handling

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,4 +16,4 @@ default['le']['datahub']['port'] = 10000
 default['le']['pull-server-side-config'] = true
 
 # PGP Key Server
-default['le']['pgp_key_server'] = 'pgp.mit.edu'
+default['le']['pgp_key_server'] = 'ha.pool.sks-keyservers.net'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -25,7 +25,7 @@ case node['platform']
       distribution node['lsb']['codename']
       components ['main']
       keyserver node['le']['pgp_key_server']
-      key 'C43C79AD'
+      key 'FA7FA2E59A243096E1B4105DA5270289C43C79AD'
       retries 3
     end
   when 'centos', 'redhat', 'amazon', 'scientific'
@@ -42,7 +42,7 @@ case node['platform']
       distribution node['lsb']['codename']
       components ['main']
       keyserver node['le']['pgp_key_server']
-      key 'C43C79AD'
+      key 'FA7FA2E59A243096E1B4105DA5270289C43C79AD'
       retries 3
     end
 end


### PR DESCRIPTION
1. Specify the full key fingerprint. (avoiding evil32)
1. Use a HA keyserver pool.